### PR TITLE
Improve error handling in engine.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ license = "AGPL-3.0"
 [dependencies]
 tokio = { version = "1.43.0", features = ["full"] }
 lru = "0.12.3"
+thiserror = "1.0"
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }

--- a/benches/engine_basic_benchmark.rs
+++ b/benches/engine_basic_benchmark.rs
@@ -15,7 +15,7 @@ fn engine_benchmark(c: &mut Criterion) {
     c.bench_function("engine set", |b| {
         b.iter(|| {
             rt.block_on(async {
-                engine.set(black_box(key), black_box(value.to_vec())).await;
+                engine.set(black_box(key), black_box(value.to_vec())).await.unwrap();
             });
         })
     });
@@ -23,7 +23,7 @@ fn engine_benchmark(c: &mut Criterion) {
     c.bench_function("engine get", |b| {
         b.iter(|| {
             rt.block_on(async {
-                engine.get(black_box(key)).await;
+                engine.get(black_box(key)).await.unwrap();
             });
         })
     });
@@ -36,6 +36,7 @@ fn engine_benchmark(c: &mut Criterion) {
                 let _ = engine
                     .scan(black_box(start_key.to_vec())..black_box(end_key.to_vec()))
                     .await
+                    .unwrap()
                     .collect::<Vec<_>>();
             });
         })
@@ -44,7 +45,7 @@ fn engine_benchmark(c: &mut Criterion) {
     c.bench_function("engine del", |b| {
         b.iter(|| {
             rt.block_on(async {
-                engine.del(black_box(key)).await;
+                engine.del(black_box(key)).await.unwrap();
             });
         })
     });

--- a/benches/engine_seq_benchmark.rs
+++ b/benches/engine_seq_benchmark.rs
@@ -14,7 +14,7 @@ async fn engine_benchmark(c: &mut Criterion, value_size: usize) {
             let key_str = format!("key{}", i);
             let key = key_str.as_bytes();
             Runtime::new().unwrap().block_on(async {
-                engine.set(black_box(key), black_box(value.to_vec())).await;
+                engine.set(black_box(key), black_box(value.to_vec())).await.unwrap();
             });
             i += 1;
         })
@@ -26,7 +26,7 @@ async fn engine_benchmark(c: &mut Criterion, value_size: usize) {
             let key_str = format!("key{}", i);
             let key = key_str.as_bytes();
             Runtime::new().unwrap().block_on(async {
-                engine.get(black_box(key)).await;
+                engine.get(black_box(key)).await.unwrap();
             });
             i += 1;
         })
@@ -40,6 +40,7 @@ async fn engine_benchmark(c: &mut Criterion, value_size: usize) {
                 let _ = engine
                     .scan(black_box(start_key.to_vec())..black_box(end_key.to_vec()))
                     .await
+                    .unwrap()
                     .collect::<Vec<_>>();
             });
         })
@@ -51,7 +52,7 @@ async fn engine_benchmark(c: &mut Criterion, value_size: usize) {
             let key_str = format!("key{}", i);
             let key = key_str.as_bytes();
             Runtime::new().unwrap().block_on(async {
-                engine.del(black_box(key)).await;
+                engine.del(black_box(key)).await.unwrap();
             });
             i += 1;
         })

--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -9,24 +9,35 @@ async fn main() {
     // Set a value
     let key = b"key";
     let value = b"value";
-    engine.set(key, value.to_vec()).await;
+    if let Err(e) = engine.set(key, value.to_vec()).await {
+        eprintln!("Error setting value: {}", e);
+    }
 
     // Get a value
-    let get_value = engine.get(key).await;
-    println!("Got value: {}", String::from_utf8_lossy(&get_value));
+    match engine.get(key).await {
+        Some(get_value) => println!("Got value: {}", String::from_utf8_lossy(&get_value)),
+        None => println!("Key not found"),
+    }
 
     // Delete a value
-    engine.del(key).await;
+    if let Err(e) = engine.del(key).await {
+        eprintln!("Error deleting value: {}", e);
+    }
 
     // Scan for values
-    let values = engine.scan(b"a".to_vec()..b"z".to_vec()).await;
-    for (key, value) in values {
-        println!(
-            "Got key: {}, value: {}",
-            String::from_utf8_lossy(&key),
-            String::from_utf8_lossy(&value)
-        );
+    match engine.scan(b"a".to_vec()..b"z".to_vec()).await {
+        Ok(values) => {
+            for (key, value) in values {
+                println!(
+                    "Got key: {}, value: {}",
+                    String::from_utf8_lossy(&key),
+                    String::from_utf8_lossy(&value)
+                );
+            }
+        }
+        Err(e) => eprintln!("Error scanning values: {}", e),
     }
+
     // Clean up
     drop(engine);
 }


### PR DESCRIPTION
Update error handling in `src/engine.rs` to use `Option` and `Result`.

* Modify `get` method to return `Option<Vec<u8>>` instead of `Vec<u8>`.
* Modify `set` method to return `Result<(), std::io::Error>` instead of `()`.
* Modify `del` method to return `Result<(), std::io::Error>` instead of `()`.
* Modify `scan` method to return `Result<Box<dyn Iterator<Item = (Vec<u8>, Vec<u8>)> + 'a>, std::io::Error>` instead of `Box<dyn Iterator<Item = (Vec<u8>, Vec<u8>)> + 'a>`.
* Modify `flush` and `compact` methods to return `Result<(), std::io::Error>` instead of `()`.

* Update `examples/basic_usage.rs` to handle the new error handling in `get`, `set`, `del`, and `scan` methods.
* Update `benches/engine_basic_benchmark.rs` to handle the new error handling in `get`, `set`, `del`, and `scan` methods.
* Update `benches/engine_seq_benchmark.rs` to handle the new error handling in `get`, `set`, `del`, and `scan` methods.
* Add `thiserror` dependency in `Cargo.toml` for better error handling.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jackysp/tegdb/pull/4?shareId=5bd62651-20e0-4eb0-a62a-87c36c15f219).