### PR TITLE
Add CI test for basic_usage example

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,6 +29,8 @@ jobs:
       run: cargo build --lib --features async
     - name: Run tests
       run: cargo test --lib --features async
+    - name: Run example
+      run: cargo run --example basic_usage
     - name: Run benchmarks
       if: github.event_name == 'schedule'
       run: cargo bench --features async > benchmarks.txt

--- a/examples/basic_usage.rs
+++ b/examples/basic_usage.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 use tegdb::Engine;
 
 #[tokio::main]
+#[cfg(not(test))]
 async fn main() {
     let path = PathBuf::from("test.db");
     let mut engine = Engine::new(path.clone());
@@ -40,4 +41,14 @@ async fn main() {
 
     // Clean up
     drop(engine);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_main() {
+        main().await;
+    }
 }


### PR DESCRIPTION
Add tests for `examples/basic_usage.rs` in GitHub Action CI.

* Modify `examples/basic_usage.rs` to add `#[cfg(test)]` attribute to the `main` function and create a new `#[tokio::test]` function to call the `main` function for testing.
* Update `.github/workflows/rust.yml` to include a new step to run `cargo run --example basic_usage` after the "Run tests" step.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jackysp/tegdb/pull/6?shareId=39e2367b-4cdf-4207-a62c-cea4af30846d).