### PR TITLE
Optimize memory usage in engine

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ license = "AGPL-3.0"
 
 [dependencies]
 tokio = { version = "1.43.0", features = ["full"] }
+parking_lot = "0.11.1"
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }


### PR DESCRIPTION
Refactor `Engine` to use more efficient memory and locking mechanisms.

* **Memory Optimization**
  - Change the return type of the `get` method to `Option<&Vec<u8>>` to return a reference to the value instead of cloning it.
  - Modify the `scan` method to return the iterator directly instead of collecting the range into a `Vec` and then converting it back to an iterator.

* **Locking Mechanisms**
  - Replace the separate locks for `log` and `key_map` with a single `RwLock` for the entire `Engine` struct.
  - Use `parking_lot`'s `Mutex` and `RwLock` instead of the standard library's `Mutex` and `RwLock` for more efficient locking mechanisms.

* **Dependency Update**
  - Add `parking_lot` dependency to the `[dependencies]` section in `Cargo.toml`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jackysp/tegdb/pull/7?shareId=ea74fb24-3872-4ad2-8ba6-ef1218c751f6).